### PR TITLE
fix: fix plugin support

### DIFF
--- a/packages/uni-app-types/src/volar-plugin.ts
+++ b/packages/uni-app-types/src/volar-plugin.ts
@@ -1,24 +1,8 @@
 const nativeTags = ["block", "component", "template", "slot"];
-export default [
-  // [2.0.14, ]
-  () => {
-    return {
-      version: 2,
-      resolveTemplateCompilerOptions(options: Record<string, any>) {
-        options.isNativeTag = (tag: string) => nativeTags.includes(tag);
-        return options;
-      },
-    };
+export default () => ({
+  version: 2,
+  resolveTemplateCompilerOptions(options: Record<string, any>) {
+    options.isNativeTag = (tag: string) => nativeTags.includes(tag);
+    return options;
   },
-  // [2.0.0, 2.0.13]
-  ({ vueCompilerOptions }: Record<string, any>) => {
-    vueCompilerOptions.nativeTags = nativeTags;
-    return { version: 2 };
-  },
-  // [1.0.0, 1.8.27]
-  ({ vueCompilerOptions }: Record<string, any>) => {
-    vueCompilerOptions.nativeTags = nativeTags;
-    vueCompilerOptions.experimentalRuntimeMode = "runtime-uni-app";
-    return { version: 1 };
-  },
-];
+});


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing! We highly recommend reading [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer) first to get an idea of our current state, and we appreciate your understanding!
感谢你的贡献！我们非常推荐先阅读 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer) 以了解我们目前的状态，感谢你的理解！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

Volar v2.0.28 https://github.com/vuejs/language-tools/pull/4581
* 不再支持 `(PluginContext => PluginReturn)[]` 形式的插件，
* 新增支持 `PluginContext => (PluginReturn | PluginReturn[])` 形式的插件

正好 uni-types 新版本不再支持 volar <2.0.14，本 PR
* 清理老版本插件，
* 调整为 volar 一直支持的 `PluginContext => PluginReturn` 格式

### Linked Issues 关联的 Issues

Fixes #9
Fixes https://github.com/uni-helper/uni-app-types/issues/67

### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified API for resolving template compiler options with a single cohesive function.
	- Introduced a new property `isNativeTag` to enhance tag handling.
  
- **Refactor**
	- Streamlined code by consolidating multiple functions into one, improving readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->